### PR TITLE
Fix negative block sizes

### DIFF
--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -1,0 +1,36 @@
+package goavro
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCrashers_OCFReader(t *testing.T) {
+	var crashers = map[string]string{
+		"scan: negative block sizes": "Obj\x01\x04\x16avro.schema\x96\x05{" +
+			"\"type\":\"record\",\"nam" +
+			"e\":\"c0000000\",\"00000" +
+			"0000\":\"00000000000\"," +
+			"\"fields\":[{\"name\":\"u" +
+			"0000000\",\"type\":\"str" +
+			"ing\",\"000\":\"00000000" +
+			"0000\"},{\"name\":\"c000" +
+			"000\",\"type\":\"string\"" +
+			",\"000\":\"000000000000" +
+			"00000000000000000000" +
+			"0\"},{\"name\":\"t000000" +
+			"00\",\"type\":\"long\",\"0" +
+			"00\":\"000000000000000" +
+			"0000000000000000\"}]," +
+			"\"0000\":\"000000000000" +
+			"00000000000000000000" +
+			"00000000\"}\x14000000000" +
+			"0\b0000\x000000000000000" +
+			"0000\xd90",
+	}
+
+	for testName, f := range crashers {
+		t.Logf("Testing: %s", testName)
+		NewOCFReader(strings.NewReader(f))
+	}
+}

--- a/ocf_reader.go
+++ b/ocf_reader.go
@@ -135,6 +135,10 @@ func (ocfr *OCFReader) Scan() bool {
 			ocfr.err = fmt.Errorf("cannot read block size: %d; %s", blockSize, ocfr.err)
 			return false
 		}
+		if blockSize < 0 {
+			ocfr.err = fmt.Errorf("the size of a block can't be negative")
+			return false
+		}
 
 		// read entire block into buffer
 		ocfr.block = make([]byte, blockSize)


### PR DESCRIPTION
If the blockSize ends up negative, then the make on line 140 (https://github.com/karrick/goavro/blob/df05d884f771477a8115ea2defc0cafb7c836e42/ocf_reader.go#L140) will panic.