### PR TITLE
Manage record fields with default values when reading from binary

### DIFF
--- a/record.go
+++ b/record.go
@@ -59,11 +59,16 @@ func makeRecordCodec(st map[string]*Codec, enclosingNamespace string, schemaMap 
 				defaultValue = Union(fieldCodec.schema, defaultValue)
 			}
 			// attempt to encode default value using codec
-			_, err = fieldCodec.binaryFromNative(nil, defaultValue)
+			binaryValue, err := fieldCodec.binaryFromNative(nil, defaultValue)
 			if err != nil {
 				return nil, fmt.Errorf("Record %q field %q: default value ought to encode using field schema: %s", c.typeName, fieldName, err)
 			}
-			defaultValueFromName[fieldName] = defaultValue
+			// decode it back so we have the right type
+			nativeValue, _, err := fieldCodec.nativeFromBinary(binaryValue)
+			if err != nil {
+				return nil, fmt.Errorf("Record %q field %q: default value cannot be decoded back: %s", c.typeName, fieldName, err)
+			}
+			defaultValueFromName[fieldName] = nativeValue
 		}
 
 		nameFromIndex[i] = fieldName

--- a/record.go
+++ b/record.go
@@ -106,6 +106,18 @@ func makeRecordCodec(st map[string]*Codec, enclosingNamespace string, schemaMap 
 			name := nameFromIndex[i]
 			var value interface{}
 			var err error
+			var ok bool
+
+			// NOTE: If we finished the buffer and there are still fields to fill,
+			// use default value if specified
+			if len(buf) == 0 {
+				if value, ok = defaultValueFromName[name]; !ok {
+					return nil, nil, fmt.Errorf("cannot decode binary record %q field %q: schema does not specify default value and no value provided", c.typeName, name)
+				}
+				recordMap[name] = value
+				continue
+			}
+
 			value, buf, err = fieldCodec.nativeFromBinary(buf)
 			if err != nil {
 				return nil, nil, fmt.Errorf("cannot decode binary record %q field %q: %s", c.typeName, name, err)

--- a/record_test.go
+++ b/record_test.go
@@ -84,7 +84,36 @@ func TestRecordDecodedEmptyBuffer(t *testing.T) {
 }
 
 func TestRecordDecodedDefaultValue(t *testing.T) {
-	testBinaryDecodePass(t, `{"type":"record","name":"foo","fields":[{"name":"field1","type":"int","default":0}]}`, map[string]int{"field1": 0}, nil)
+
+	schema := `{"type":"record","name":"foo","fields":[{"name":"field1","type":"long","default":0}]}`
+	datum := map[string]int64{"field1": 0}
+	codec, err := goavro.NewCodec(schema)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	value, remaining, err := codec.NativeFromBinary(nil)
+	if err != nil {
+		t.Fatalf("schema: %s; %s", schema, err)
+	}
+
+	// remaining ought to be empty because there is nothing remaining to be
+	// decoded
+	if actual, expected := len(remaining), 0; actual != expected {
+		t.Errorf("schema: %s; Datum: %v; Actual: %#v; Expected: %#v", schema, datum, actual, expected)
+	}
+	native, ok := value.(map[string]interface{})
+	if !ok {
+		t.Fatalf("Bad type for return value: %T", value)
+	}
+	field1, ok := native["field1"]
+	if !ok {
+		t.Fatalf("default value not taken into account: %v", native)
+	}
+	if field1 != datum["field1"] {
+		t.Fatalf("default value is incorrect: Actual:(%T)%v Expected:(%T)%v", field1, field1, datum["field1"], datum["field1"])
+	}
+
 }
 
 func TestRecordFieldTypeHasPrimitiveName(t *testing.T) {

--- a/record_test.go
+++ b/record_test.go
@@ -80,7 +80,11 @@ func TestSchemaRecordFieldWithDefaults(t *testing.T) {
 }
 
 func TestRecordDecodedEmptyBuffer(t *testing.T) {
-	testBinaryDecodeFailShortBuffer(t, `{"type":"record","name":"foo","fields":[{"name":"field1","type":"int"}]}`, nil)
+	testBinaryDecodeFail(t, `{"type":"record","name":"foo","fields":[{"name":"field1","type":"int"}]}`, nil, "schema does not specify default value and no value provided")
+}
+
+func TestRecordDecodedDefaultValue(t *testing.T) {
+	testBinaryDecodePass(t, `{"type":"record","name":"foo","fields":[{"name":"field1","type":"int","default":0}]}`, map[string]int{"field1": 0}, nil)
 }
 
 func TestRecordFieldTypeHasPrimitiveName(t *testing.T) {
@@ -415,7 +419,7 @@ func TestRecordRecursiveRoundTrip(t *testing.T) {
 	codec, err := goavro.NewCodec(`
 {
   "type": "record",
-  "name": "LongList",                  
+  "name": "LongList",
   "fields" : [
     {"name": "next", "type": ["null", "LongList"], "default": null}
   ]


### PR DESCRIPTION
This handles the case of a compatible schema evolution, when new fields with default values are added.
With this, consumers using the new schema can read messages produced with the old schema.